### PR TITLE
Add Jenkins & Argo modules with pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,29 @@
+pipeline {
+  agent any
+  environment {
+    REGION = 'eu-central-1'
+    ECR_URL = "${ECR_URL}"
+  }
+  stages {
+    stage('Build image') {
+      steps {
+        sh 'docker build -t $ECR_URL:$GIT_COMMIT app'
+      }
+    }
+    stage('Push to ECR') {
+      steps {
+        sh '''aws ecr get-login-password --region $REGION | docker login --username AWS --password-stdin $ECR_URL
+        docker push $ECR_URL:$GIT_COMMIT'''
+      }
+    }
+    stage('Update chart') {
+      steps {
+        sh "sed -i 's/tag: \".*\"/tag: \"$GIT_COMMIT\"/' src/charts/django-app/values.yaml"
+        sh 'git config user.email "jenkins@example.com"'
+        sh 'git config user.name "jenkins"'
+        sh 'git commit -am "Update image tag"'
+        sh 'git push origin $GIT_BRANCH'
+      }
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,74 +1,38 @@
-# Lesson-7 — команды запуска
+# Lesson-8-9 CI/CD
+
+This project demonstrates a simple CI/CD chain with **Terraform**, **Jenkins** and **Argo CD**.
+
+## Terraform usage
 
 ```bash
-aws s3api create-bucket \
-    --bucket hw-7-terraform \
-    --region eu-central-1 \
-    --create-bucket-configuration LocationConstraint=eu-central-1
-
-aws dynamodb create-table \
-    --table-name hw-7-terraform-locks \
-    --attribute-definitions AttributeName=LockID,AttributeType=S \
-    --key-schema            AttributeName=LockID,KeyType=HASH \
-    --billing-mode PAY_PER_REQUEST \
-    --region eu-central-1
-
 cd ./src
-
-terraform init -migrate-state
-terraform init -reconfigure
-
-terraform import module.s3_backend.aws_s3_bucket.this hw-7-terraform
-terraform import module.s3_backend.aws_dynamodb_table.this hw-7-terraform-locks
-
-terraform state list | grep module.s3_backend
-
-terraform validate
-terraform plan
+terraform init
 terraform apply
-
-terraform output
-terraform output -raw ecr_repository_url
-terraform output -raw cluster_name
-
-ECR_URL=$(terraform output -raw ecr_repository_url)
-EKS_CLUSTER=$(terraform output -raw cluster_name)
-REGION=eu-central-1
-PRINCIPAL_ARN=$(aws sts get-caller-identity --query Arn --output text)
-AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
-
-aws ecr get-login-password --region "${REGION}" \
-  | docker login --username AWS --password-stdin "${ECR_URL}"
-docker build -t lesson-7-django:latest ../app
-docker tag lesson-7-django:latest "${ECR_URL}:latest"
-docker push "${ECR_URL}:latest"
-
-helm template django-app ./charts/django-app \
-  --set image.repository="${ECR_URL}" \
-  --set image.tag=latest | less
-
-helm upgrade --install django-app ./charts/django-app \
-  --set image.repository="${ECR_URL}" \
-  --set image.tag=latest
-
-kubectl get pods
-kubectl get hpa
-
-POD=$(kubectl get pods -l app.kubernetes.io/name=django-app -o jsonpath='{.items[0].metadata.name}')
-kubectl exec -it "$POD" -- env | grep DJANGO
-
-ECR_REPO=lesson-7-django
-aws ecr delete-repository --repository-name $ECR_REPO --force --region $REGION
-
-aws ec2 describe-network-interfaces \
-  --region $REGION \
-  --filters Name=vpc-id,Values=$VPC_ID \
-  --query 'NetworkInterfaces[].{Id:NetworkInterfaceId,Status:Status,Desc:Description,AttachId:Attachment.AttachmentId,Instance:Attachment.InstanceId,Subnet:SubnetId,PrivateIp:PrivateIpAddress}' \
-  --output table
-
-terraform destroy
-
-cd ../
-
-bash purge-and-delete-s3.sh hw-7-terraform eu-central-1
 ```
+
+Infrastructure includes ECR, EKS cluster, Jenkins and Argo CD installed via Helm charts.
+
+## Jenkins pipeline
+
+`Jenkinsfile` contains a pipeline which:
+1. Builds a Docker image for the Django application.
+2. Pushes the image to ECR.
+3. Updates the image tag in the Helm chart and pushes changes to `main`.
+
+After applying Terraform open Jenkins (service `jenkins` in namespace `jenkins`) and run the pipeline.
+
+## Argo CD
+
+Argo CD watches the Helm chart and automatically deploys new revisions into the cluster. Use port-forward to access the UI:
+
+```bash
+kubectl -n argocd port-forward svc/argocd-server 8080:443
+```
+
+Login with the password from:
+
+```bash
+kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath='{.data.password}' | base64 -d
+```
+
+Once the Jenkins pipeline updates the chart, Argo CD will sync the application.

--- a/src/main.tf
+++ b/src/main.tf
@@ -32,3 +32,11 @@ module "eks" {
   private_subnet_ids = module.vpc.private_subnet_ids
   public_subnet_ids  = module.vpc.public_subnet_ids
 }
+
+module "jenkins" {
+  source = "./modules/jenkins"
+}
+
+module "argo_cd" {
+  source = "./modules/argo_cd"
+}

--- a/src/modules/argo_cd/argocd.tf
+++ b/src/modules/argo_cd/argocd.tf
@@ -1,0 +1,9 @@
+resource "helm_release" "argocd" {
+  name       = "argocd"
+  repository = "https://argoproj.github.io/argo-helm"
+  chart      = "argo-cd"
+  version    = var.chart_version
+  namespace  = var.namespace
+  create_namespace = true
+  values     = [file("${path.module}/values.yaml")]
+}

--- a/src/modules/argo_cd/charts/Chart.yaml
+++ b/src/modules/argo_cd/charts/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: argocd-apps
+version: 0.1.0

--- a/src/modules/argo_cd/charts/templates/application.yaml
+++ b/src/modules/argo_cd/charts/templates/application.yaml
@@ -1,0 +1,18 @@
+{{- range .Values.applications }}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ .name }}
+  namespace: {{ $.Release.Namespace }}
+spec:
+  project: default
+  source:
+    repoURL: {{ .repoURL }}
+    targetRevision: {{ .targetRevision | default "HEAD" }}
+    path: {{ .path }}
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: {{ .namespace }}
+  syncPolicy:
+    automated: {}
+{{- end }}

--- a/src/modules/argo_cd/charts/templates/repository.yaml
+++ b/src/modules/argo_cd/charts/templates/repository.yaml
@@ -1,0 +1,13 @@
+{{- range .Values.repositories }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .name }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    argocd.argoproj.io/secret-type: repository
+stringData:
+  url: {{ .url }}
+  password: {{ .password }}
+  username: {{ .username }}
+{{- end }}

--- a/src/modules/argo_cd/charts/values.yaml
+++ b/src/modules/argo_cd/charts/values.yaml
@@ -1,0 +1,2 @@
+applications: []
+repositories: []

--- a/src/modules/argo_cd/outputs.tf
+++ b/src/modules/argo_cd/outputs.tf
@@ -1,0 +1,3 @@
+output "argocd_namespace" {
+  value = var.namespace
+}

--- a/src/modules/argo_cd/values.yaml
+++ b/src/modules/argo_cd/values.yaml
@@ -1,0 +1,3 @@
+server:
+  service:
+    type: LoadBalancer

--- a/src/modules/argo_cd/variables.tf
+++ b/src/modules/argo_cd/variables.tf
@@ -1,0 +1,4 @@
+variable "namespace" { type = string default = "argocd" }
+variable "chart_version" { type = string default = "7.1.3" }
+variable "repo_url" { type = string default = "" }
+variable "chart_branch" { type = string default = "main" }

--- a/src/modules/jenkins/jenkins.tf
+++ b/src/modules/jenkins/jenkins.tf
@@ -1,0 +1,9 @@
+resource "helm_release" "jenkins" {
+  name       = "jenkins"
+  repository = "https://charts.jenkins.io"
+  chart      = "jenkins"
+  version    = var.chart_version
+  namespace  = var.namespace
+  create_namespace = true
+  values     = [file("${path.module}/values.yaml")]
+}

--- a/src/modules/jenkins/outputs.tf
+++ b/src/modules/jenkins/outputs.tf
@@ -1,0 +1,3 @@
+output "service_name" {
+  value = helm_release.jenkins.name
+}

--- a/src/modules/jenkins/values.yaml
+++ b/src/modules/jenkins/values.yaml
@@ -1,0 +1,5 @@
+controller:
+  installPlugins:
+    - kubernetes:latest
+    - workflow-aggregator:latest
+  serviceType: LoadBalancer

--- a/src/modules/jenkins/variables.tf
+++ b/src/modules/jenkins/variables.tf
@@ -1,0 +1,2 @@
+variable "namespace" { type = string default = "jenkins" }
+variable "chart_version" { type = string default = "5.0.7" }


### PR DESCRIPTION
## Summary
- add Jenkinsfile with ECR push and chart update
- create Terraform modules for Jenkins and Argo CD installation
- register the modules in `main.tf`
- provide minimal Helm chart skeleton for Argo applications
- update README for new CI/CD flow

## Testing
- `apt-get update` *(fails: repository not signed because internet access is blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687ff02ed988832b8a00b2589a4ebb8c